### PR TITLE
feat(rollup): Use rollup 0.48.0 option structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install rollup @metahub/karma-rollup-preprocessor --save-dev
 
 ## Configuration
 
-All the [rollup](https://github.com/rollup/rollup) options can be passed to `rollupPreprocessor.options`.
+All the [rollup](https://rollupjs.org/#big-list-of-options) options can be passed to `rollupPreprocessor.options`.
 
 In addition the preprocessor accept a `transformPath` function, to rewrite the path on which the files are deployed on the Karma webserver. If not specified, the processed files will be accessible with the same paths as the originals. For example `test/unit.test.js` will be deployed as `base/test/unit.test.js`.
 
@@ -42,11 +42,13 @@ module.exports = function(config) {
 
     rollupPreprocessor: {
       options: {
-        // To include inlined sourcemaps as data URIs
-        sourcemap: true,
+        output: {
+          // To include inlined sourcemaps as data URIs
+          sourcemap: true,
+          format: 'iife'
+        },
         // To compile with babel using es2015 preset
         plugins: [babel({presets: [['es2015', {modules: false}]]})]
-        format: 'iife',
       },
       // File src/js/main.js will be deployed on Karma with path base/script/main.js
       transformPath: filePath => filePath.replace('src/js', 'script')
@@ -56,7 +58,7 @@ module.exports = function(config) {
 ```
 **_Note: Karma can auto-load plugins named `karma-*` (see [plugins](http://karma-runner.github.io/1.0/config/plugins.html)). Unfortunatly it doesn't work with [scoped packages](https://docs.npmjs.com/misc/scope), therefore `@metahub/karma-rollup-preprocessor` has to be explicitly added to the `plugins` configuration. In order to continue to automatically load other plugins you can add `karma-*` to the `plugins` configuration._**
 
-**_Note: `@metahub/karma-rollup-preprocessor` embed its own watcher to monitor js module dependencies, therefore only the main entry point has to be configured in Karma. If Karma is configured with `autoWatch: true`, the modification of an imported js module partial will trigger a new build and test run._**
+**_Note: `@metahub/karma-rollup-preprocessor` embed its own watcher to monitor js module dependencies, therefore only the main entry point has to be configured in Karma. If Karma is configured with `autoWatch: true`, the modification of an imported js module will trigger a new build and test run._**
 
 ### Configured Preprocessors
 See [configured preprocessors](http://karma-runner.github.io/1.0/config/preprocessors.html).
@@ -73,17 +75,21 @@ module.exports = function(config) {
       rollup_1: {
         base: 'rollup',
         options: {
-          sourcemap: false,
+          output: {
+            sourcemap: false,
+            format: 'iife'
+          },
           plugins: [babel({presets: [['es2015', {modules: false}]]})]
-          format: 'iife',
         },
       },
       rollup_2: {
         base: 'rollup',
         options: {
-          sourcemap: true,
+          output: {
+            sourcemap: true,
+            format: 'iife'
+          }
           plugins: [babel({presets: [['es2015', {modules: false}]]})]
-          format: 'iife',
         },
       },
     },
@@ -112,13 +118,13 @@ npm install rollup @metahub/karma-rollup-preprocessor rollup-plugin-babel babel-
 |   ├── dependency.js // imported by src/main.js
 ```
 ```javascript
-// main.js
+// test/main.js
 
 import './*.test.js'; // using https://github.com/kei-ito/rollup-plugin-glob-import
 
 ```
 ```javascript
-// unit-test-1.test.js
+// test/unit-test-1.test.js
 
 import {myUtil} from './helpers/utils.js';
 
@@ -129,7 +135,7 @@ describe('My unit tests', () => {
 });
 ```
 ```javascript
-// unit-test-2.test.js
+// test/unit-test-2.test.js
 
 import {myOtherUtil} from './helpers/utils.js';
 
@@ -152,9 +158,11 @@ module.exports = function(config) {
 
     rollupPreprocessor: {
       options: {
-        sourcemap: true,
+        output: {
+          sourcemap: true,
+          format: 'iife'
+        },
         plugins: [globImport(), babel({presets: [['es2015', {modules: false}]]})]
-        format: 'iife',
       },
     },
   });

--- a/src/index.js
+++ b/src/index.js
@@ -53,9 +53,12 @@ function createRollupPreprocessor(args, config, logger, server) {
     // Clone the options because we need to mutate them
     const opts = Object.assign({}, options);
 
+    if (!opts.output) {
+      opts.output = {};
+    }
     // Inline source maps
-    if (opts.sourcemap) {
-      opts.sourcemap = 'inline';
+    if (opts.sourcemap || opts.output.sourcemap) {
+      opts.output.sourcemap = 'inline';
     }
     opts.input = file.originalPath;
     opts.cache = cache;
@@ -109,10 +112,10 @@ function createRollupPreprocessor(args, config, logger, server) {
             }
           }
           cache = bundle;
-          return bundle.generate(opts);
+          return bundle.generate(opts.output);
         })
         .then(generated => {
-          if (opts.sourcemap && generated.map) {
+          if (opts.output.sourcemap && generated.map) {
             generated.map.file = path.basename(file.path);
             file.sourceMap = generated.map;
             return `${generated.code}\n//# sourceMappingURL=${generated.map.toUrl()}\n`;

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -32,14 +32,14 @@ export function waitFor(emitter, event, timeout = 30000) {
  * @return {Compiled} compiled code and source map.
  */
 export async function compile(file, options = {}) {
-  if (options.sourcemap) {
-    options.sourcemap = 'inline';
+  if (options.output.sourcemap) {
+    options.output.sourcemap = 'inline';
   }
   options.input = file;
-  const {code, map} = await (await rollup(options)).generate(options);
+  const {code, map} = await (await rollup(options)).generate(options.output);
 
   if (map) {
     map.file = path.basename(file);
   }
-  return {code: options.sourcemap ? `${code}\n//# sourceMappingURL=${map.toUrl()}\n` : code, map};
+  return {code: options.output.sourcemap ? `${code}\n//# sourceMappingURL=${map.toUrl()}\n` : code, map};
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -19,7 +19,7 @@ test.after(() => {
 test('Compile JS file', async t => {
   const {success, error, disconnected, errMsg} = await run('test/fixtures/basic.js', {
     options: {
-      format: 'umd',
+      output: {format: 'umd'},
       plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
     },
   });
@@ -32,8 +32,7 @@ test('Compile JS file', async t => {
 test('Compile JS file with sourcemap and verify the reporter logs use the sourcemap', async t => {
   const {success, failed, error, disconnected} = await run('test/fixtures/falsy-assert.js', {
     options: {
-      sourcemap: true,
-      format: 'umd',
+      output: {sourcemap: true, format: 'umd'},
       plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
     },
   });
@@ -54,7 +53,7 @@ test('Compile JS file with sourcemap and verify the reporter logs use the source
 test('Compile JS file with custom preprocessor', async t => {
   const {success, error, disconnected, errMsg} = await run('test/fixtures/basic.custom.js', {
     options: {
-      format: 'umd',
+      output: {format: 'umd'},
       plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
     },
   });
@@ -87,7 +86,7 @@ test('Re-compile JS file when dependency is modified', async t => {
 
   const {server, watcher} = await watch([fixture.replace('fixtures', '*').replace('basic', '+(basic|nomatch)')], {
     options: {
-      format: 'umd',
+      output: {format: 'umd'},
       plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
     },
   });

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -10,7 +10,7 @@ import {mockPreprocessor} from './helpers/mock';
 test('Compile JS file', async t => {
   const fixture = 'test/fixtures/basic.js';
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, debug} = await mockPreprocessor({}, {rollupPreprocessor: {options}});
@@ -24,8 +24,7 @@ test('Compile JS file', async t => {
 test('Compile JS file with sourcemap (options.sourcemap)', async t => {
   const fixture = 'test/fixtures/basic.js';
   const options = {
-    sourcemap: true,
-    format: 'umd',
+    output: {sourcemap: true, format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, debug} = await mockPreprocessor({}, {rollupPreprocessor: {options}});
@@ -43,8 +42,7 @@ test('Compile JS file with sourcemap (options.sourcemap)', async t => {
 test('Compile JS file with sourcemap (options.sourcemap) and custom preprocessor', async t => {
   const fixture = 'test/fixtures/basic.custom.js';
   const options = {
-    sourcemap: true,
-    format: 'umd',
+    output: {sourcemap: true, format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, debug} = await mockPreprocessor({options});
@@ -62,7 +60,7 @@ test('Compile JS file with sourcemap (options.sourcemap) and custom preprocessor
 test('Compile JS file with custom transformPath', async t => {
   const fixture = 'test/fixtures/basic.js';
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const transformPath = spy(filePath => filePath.replace(/\.(js)$/, '.jsx').replace('fixtures/', ''));
@@ -78,7 +76,7 @@ test('Compile JS file with custom transformPath', async t => {
 test('Compile JS file with custom transformPath and custom preprocessor', async t => {
   const fixture = 'test/fixtures/basic.js';
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const transformPath = spy(filePath => filePath.replace(/\.(js)$/, '.jsx').replace('fixtures/', ''));
@@ -113,7 +111,7 @@ test('Instanciate watcher only if autoWatch is true', async t => {
 test('Add dependency to watcher', async t => {
   const fixture = 'test/fixtures/basic.js';
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const module = path.resolve('test/fixtures/modules/module.js');
@@ -135,7 +133,7 @@ test('Add dependency to watcher for file added with glob', async t => {
   const fixture = 'test/fixtures/basic.js';
   const glob = 'test/*/+(basic|nomatch).js';
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const module = path.resolve('test/fixtures/modules/module.js');
@@ -156,7 +154,7 @@ test('Add dependency to watcher for file added with glob', async t => {
 test('Do not add dependency to watcher if parent is not watched', async t => {
   const fixture = 'test/fixtures/basic.js';
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, watcher} = await mockPreprocessor(
@@ -178,7 +176,7 @@ test('Add dependency to watcher only once, even when its referenced multiple tim
   const moduleAlt = path.join(includePath, 'module-alt.js');
   const subModule = path.join(includePath, 'sub-module.js');
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, debug, watcher} = await mockPreprocessor(
@@ -212,7 +210,7 @@ test('Add dependency to watcher only once, even when its referenced multiple tim
 test('Add dependency to watcher only once if file is overwritten', async t => {
   const fixture = 'test/fixtures/basic.js';
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const module = path.resolve('test/fixtures/modules/module.js');
@@ -242,7 +240,7 @@ test('Remove dependency from watcher if not referenced anymore', async t => {
   const moduleAlt = path.join(includePath, 'module-alt.js');
   const subModule = path.join(includePath, 'sub-module.js');
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, debug, watcher} = await mockPreprocessor(
@@ -284,7 +282,7 @@ test('Do not remove dependency from watcher when unreferenced, if another file s
   const moduleAlt = path.join(includePath, 'module-alt.js');
   const subModule = path.join(includePath, 'sub-module.js');
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, debug, watcher} = await mockPreprocessor(
@@ -330,7 +328,7 @@ test('Do not remove dependency from watcher when different files have differents
   const moduleAlt = path.join(includePath, 'module-alt.js');
   const subModule = path.join(includePath, 'sub-module.js');
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, debug, watcher} = await mockPreprocessor(
@@ -373,7 +371,7 @@ test('Call refreshFiles when dependency is modified', async t => {
   const module = path.join(includePath, 'module.js');
   const subModule = path.join(includePath, 'sub-module.js');
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, watcher, info, refreshFiles} = await mockPreprocessor(
@@ -404,7 +402,7 @@ test('Call refreshFiles when dependency is deleted and added', async t => {
   const module = path.join(includePath, 'module.js');
   const subModule = path.join(includePath, 'sub-module.js');
   const options = {
-    format: 'umd',
+    output: {format: 'umd'},
     plugins: [babel({babelrc: false, presets: [[require.resolve('babel-preset-es2015'), {modules: false}]]})],
   };
   const {preprocessor, watcher, info, refreshFiles} = await mockPreprocessor(


### PR DESCRIPTION
BREAKING CHANGE: The preprocessor options are now consistent with the
new rollup structure released in rollup 0.48.0. Options like `format`,
`globals`, `name`, `sourcemap` now have to be set under the `output`
attribute. See
https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32